### PR TITLE
Escape query type_field values for model names with namespace.

### DIFF
--- a/lib/acts_as_solr/class_methods.rb
+++ b/lib/acts_as_solr/class_methods.rb
@@ -181,8 +181,8 @@ module ActsAsSolr #:nodoc:
     end
     
     def multi_model_suffix(options)
-      models = "AND (#{solr_configuration[:type_field]}:#{self.name}"
-      models << " OR " + options[:models].collect {|m| "#{solr_configuration[:type_field]}:" + m.to_s}.join(" OR ") if options[:models].is_a?(Array)
+      models = "AND (#{solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(self.name)}"
+      models << " OR " + options[:models].collect {|m| "#{solr_configuration[:type_field]}:" + Solr::Util.query_parser_escape(m.to_s)}.join(" OR ") if options[:models].is_a?(Array)
       models << ")"
     end
     

--- a/lib/acts_as_solr/instance_methods.rb
+++ b/lib/acts_as_solr/instance_methods.rb
@@ -40,7 +40,7 @@ module ActsAsSolr #:nodoc:
       doc.boost = validate_boost(configuration[:boost]) if configuration[:boost]
       
       doc << {:id => solr_id,
-              solr_configuration[:type_field] => self.class.name,
+              solr_configuration[:type_field] => Solr::Util.query_parser_escape(self.class.name),
               solr_configuration[:primary_key_field] => record_id(self).to_s}
 
       # iterate through the fields and add them to the document,

--- a/lib/acts_as_solr/parser_methods.rb
+++ b/lib/acts_as_solr/parser_methods.rb
@@ -107,8 +107,8 @@ module ActsAsSolr #:nodoc:
     end
 
     def solr_type_condition
-      (subclasses || []).inject("(#{solr_configuration[:type_field]}:\"#{self.name}\"") do |condition, subclass|
-        condition << " OR #{solr_configuration[:type_field]}:\"#{subclass.name}\""
+      (subclasses || []).inject("(#{solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(self.name)}") do |condition, subclass|
+        condition << " OR #{solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(subclass.name)}"
       end << ')'
     end
 

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -103,7 +103,7 @@ namespace :solr do
   
       if clear_first
         puts "Clearing index for #{model}..."
-        ActsAsSolr::Post.execute(Solr::Request::Delete.new(:query => "#{model.solr_configuration[:type_field]}:\"#{model}\""))
+        ActsAsSolr::Post.execute(Solr::Request::Delete.new(:query => "#{model.solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(model)}"))
         ActsAsSolr::Post.execute(Solr::Request::Commit.new)
       end
       


### PR DESCRIPTION
I had problems using this gem with spree_solr_search because, as of version 1.0.0, spree uses its own namespace so query strings have errors with model names like "Spree::Product".

This patch uses Solr::Util.query_parser_escape to fix that problem.
