### PR TITLE
Fix a bug in method call

### DIFF
--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -103,7 +103,7 @@ namespace :solr do
   
       if clear_first
         puts "Clearing index for #{model}..."
-        ActsAsSolr::Post.execute(Solr::Request::Delete.new(:query => "#{model.solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(model)}"))
+        ActsAsSolr::Post.execute(Solr::Request::Delete.new(:query => "#{model.solr_configuration[:type_field]}:#{Solr::Util.query_parser_escape(model.name)}"))
         ActsAsSolr::Post.execute(Solr::Request::Commit.new)
       end
       


### PR DESCRIPTION
I found a bug in one of the calls to query_parser_escape I did before. Now I pass model.name so it receives a string.

Sorry for the mistake, now I think that all is ok.
