### PR TITLE
Don't escape the field_type value when update the index.

### DIFF
--- a/lib/acts_as_solr/instance_methods.rb
+++ b/lib/acts_as_solr/instance_methods.rb
@@ -40,7 +40,7 @@ module ActsAsSolr #:nodoc:
       doc.boost = validate_boost(configuration[:boost]) if configuration[:boost]
       
       doc << {:id => solr_id,
-              solr_configuration[:type_field] => Solr::Util.query_parser_escape(self.class.name),
+              solr_configuration[:type_field] => self.class.name,
               solr_configuration[:primary_key_field] => record_id(self).to_s}
 
       # iterate through the fields and add them to the document,


### PR DESCRIPTION
The reindex process fills the type_field value but this has to be written as is, not escaped.
