### PR TITLE
Set default read timeout to 60 instead of 0

### DIFF
--- a/config/solr.yml
+++ b/config/solr.yml
@@ -6,17 +6,17 @@
 development:
   url: http://0.0.0.0:8982/solr
   jvm_options: -server -Xmx128M -Xms16M
-  timeout: 0
+  timeout: 60
   
 production:
   url: http://127.0.0.1:8983/solr
   jvm_options: -server -Xmx192M -Xms64M
-  timeout: 0
+  timeout: 60
 
 test: &TEST
   url: http://0.0.0.0:8981/solr
   jvm_options: -server -Xmx128M -Xms16M
-  timeout: 0
+  timeout: 60
 
 cucumber:
   <<: *TEST

--- a/lib/solr/connection.rb
+++ b/lib/solr/connection.rb
@@ -41,7 +41,7 @@ class Solr::Connection
     # Not actually opening the connection yet, just setting up the persistent connection.
     @connection = Net::HTTP.new(@url.host, @url.port)
   
-    @connection.read_timeout = opts[:timeout].to_i || 0
+    @connection.read_timeout = opts[:timeout].nil? ? 60 : opts[:timeout].to_i
     @username = opts[:username] if opts[:username]
     @password = opts[:password] if opts[:password]
   end


### PR DESCRIPTION
because a value of 0 causes an immediate timeout on eg. Mac OS X.

60 seconds is the default value of the ruby implementation.

This closes issue #33
