### PR TITLE
Make sure REXML entites are not encoded

### DIFF
--- a/lib/solr/xml.rb
+++ b/lib/solr/xml.rb
@@ -38,6 +38,12 @@ begin
 rescue LoadError => e # If we can't load either rubygems or libxml-ruby
   # Just use REXML.
   require 'rexml/document'
-  Solr::XML::Element = REXML::Element
-  
+  class Solr::XML::Element < REXML::Element
+    def initialize(arg = UNDEFINED, parent=nil, context=nil)
+      super(arg, parent, context)
+      @context ||= {}
+      @context[:raw] = :all if @context[:raw].nil?
+    end
+  end
+
 end


### PR DESCRIPTION
This fixes problems where quotes in queries to solr
where badly encoded if REXML was used instead of
SimpleXML. Eg. double quotes were encoded as `&quot;`
which the solr server couldn't parse.

This code has not yet been run against the specs.

closes #34
