### PR TITLE
Remove missing files from gemspec

### DIFF
--- a/acts_as_solr_reloaded.gemspec
+++ b/acts_as_solr_reloaded.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.files = [
     "LICENSE",
     "README.markdown",
-    "README.rdoc",
     "Rakefile",
     "TESTING_THE_PLUGIN",
     "VERSION",
@@ -171,7 +170,6 @@ Gem::Specification.new do |s|
     "test/models/dynamic_attribute.rb",
     "test/models/electronic.rb",
     "test/models/gadget.rb",
-    "test/models/local.rb",
     "test/models/movie.rb",
     "test/models/novel.rb",
     "test/models/post.rb",


### PR DESCRIPTION
The gemspec references some non-existant files which causes bundler to error out when using gem directly from github.
