### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,7 +54,7 @@ ActsAsSolr implements in SearchResults class an interface compatible with will_p
 In your tests
 ======
 To test code that uses `acts_as_solr` you must start a Solr server for the test environment.
-You can add to the beggining of your test/test_helper.rb the code:
+You can add to the beginning of your test/test_helper.rb the code:
 
     ENV["RAILS_ENV"] = "test"
     abort unless system 'rake solr:start' 


### PR DESCRIPTION
@dcrec1, I've corrected a typographical error in the documentation of the [acts_as_solr_reloaded](https://github.com/dcrec1/acts_as_solr_reloaded) project. Specifically, I've changed beggining to beginning. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
